### PR TITLE
feat: 봉사활동 조회 무한스크롤 기능 및 단위테스트 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,40 +1,46 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.3'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.3'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/gamsa/activity/constant/ActivityErrorCode.java
+++ b/src/main/java/com/gamsa/activity/constant/ActivityErrorCode.java
@@ -1,11 +1,11 @@
-package com.gamsa.common.constant;
+package com.gamsa.activity.constant;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum ErrorCode {
+public enum ActivityErrorCode {
 
     // 404 Not Found : 존재하지 않는 리소스 접근
     ACTIVITY_NOT_EXISTS(404, "존재하지 않는 활동입니다."),

--- a/src/main/java/com/gamsa/activity/constant/ActivitySortType.java
+++ b/src/main/java/com/gamsa/activity/constant/ActivitySortType.java
@@ -1,0 +1,9 @@
+package com.gamsa.activity.constant;
+
+import lombok.Getter;
+
+@Getter
+public class ActivitySortType {
+
+    public static final String ID = "actId";
+}

--- a/src/main/java/com/gamsa/activity/controller/ActivityController.java
+++ b/src/main/java/com/gamsa/activity/controller/ActivityController.java
@@ -4,8 +4,9 @@ import com.gamsa.activity.dto.ActivityDetailResponse;
 import com.gamsa.activity.dto.ActivityFindAllResponse;
 import com.gamsa.activity.dto.ActivitySaveRequest;
 import com.gamsa.activity.service.ActivityService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,8 +24,8 @@ public class ActivityController {
     private final ActivityService activityService;
 
     @GetMapping
-    public List<ActivityFindAllResponse> findAll() {
-        return activityService.findAll();
+    public Slice<ActivityFindAllResponse> findAll(Pageable pageable) {
+        return activityService.findAll(pageable);
     }
 
     @GetMapping("{activity-id}")

--- a/src/main/java/com/gamsa/activity/entity/ActivityJpaEntity.java
+++ b/src/main/java/com/gamsa/activity/entity/ActivityJpaEntity.java
@@ -24,7 +24,7 @@ import lombok.NoArgsConstructor;
 public class ActivityJpaEntity extends BaseEntity {
 
     @Id
-    @Column(name = "id")
+    @Column(name = "act_id")
     private Long actId;
 
     @Column(name = "act_title", length = 255)

--- a/src/main/java/com/gamsa/activity/exception/ActivityCustomException.java
+++ b/src/main/java/com/gamsa/activity/exception/ActivityCustomException.java
@@ -1,6 +1,6 @@
 package com.gamsa.activity.exception;
 
-import com.gamsa.common.constant.ErrorCode;
+import com.gamsa.activity.constant.ActivityErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -8,5 +8,5 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ActivityCustomException extends RuntimeException {
 
-    private final ErrorCode errorCode;
+    private final ActivityErrorCode activityErrorCode;
 }

--- a/src/main/java/com/gamsa/activity/repository/ActivityCustomRepository.java
+++ b/src/main/java/com/gamsa/activity/repository/ActivityCustomRepository.java
@@ -1,15 +1,11 @@
 package com.gamsa.activity.repository;
 
 import com.gamsa.activity.domain.Activity;
-import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-public interface ActivityRepository {
-
-    void save(Activity activity);
+public interface ActivityCustomRepository {
 
     Slice<Activity> findSlice(Pageable pageable);
 
-    Optional<Activity> findById(Long activityId);
 }

--- a/src/main/java/com/gamsa/activity/repository/ActivityCustomRepositoryImpl.java
+++ b/src/main/java/com/gamsa/activity/repository/ActivityCustomRepositoryImpl.java
@@ -57,9 +57,9 @@ public class ActivityCustomRepositoryImpl implements ActivityCustomRepository {
             for (Sort.Order order : pageable.getSort()) {
                 Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
                 switch (order.getProperty()) {
-                    case "id":
+                    case "actId":
                         OrderSpecifier<?> orderId = QueryDslUtil.getSortedColumn(direction,
-                            activityJpaEntity, "id");
+                            activityJpaEntity, "actId");
                         orders.add(orderId);
                         break;
                     default:

--- a/src/main/java/com/gamsa/activity/repository/ActivityCustomRepositoryImpl.java
+++ b/src/main/java/com/gamsa/activity/repository/ActivityCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.gamsa.activity.repository;
 import static com.gamsa.activity.entity.QActivityJpaEntity.activityJpaEntity;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
+import com.gamsa.activity.constant.ActivitySortType;
 import com.gamsa.activity.domain.Activity;
 import com.gamsa.activity.entity.ActivityJpaEntity;
 import com.gamsa.common.utils.QueryDslUtil;
@@ -57,9 +58,9 @@ public class ActivityCustomRepositoryImpl implements ActivityCustomRepository {
             for (Sort.Order order : pageable.getSort()) {
                 Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
                 switch (order.getProperty()) {
-                    case "actId":
+                    case ActivitySortType.ID:
                         OrderSpecifier<?> orderId = QueryDslUtil.getSortedColumn(direction,
-                            activityJpaEntity, "actId");
+                            activityJpaEntity, ActivitySortType.ID);
                         orders.add(orderId);
                         break;
                     default:

--- a/src/main/java/com/gamsa/activity/repository/ActivityCustomRepositoryImpl.java
+++ b/src/main/java/com/gamsa/activity/repository/ActivityCustomRepositoryImpl.java
@@ -1,0 +1,72 @@
+package com.gamsa.activity.repository;
+
+import static com.gamsa.activity.entity.QActivityJpaEntity.activityJpaEntity;
+import static org.springframework.util.ObjectUtils.isEmpty;
+
+import com.gamsa.activity.domain.Activity;
+import com.gamsa.activity.entity.ActivityJpaEntity;
+import com.gamsa.common.utils.QueryDslUtil;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+
+@RequiredArgsConstructor
+public class ActivityCustomRepositoryImpl implements ActivityCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Slice<Activity> findSlice(Pageable pageable) {
+        List<OrderSpecifier> orders = getAllOrderSpecifiers(pageable);
+
+        List<ActivityJpaEntity> results = jpaQueryFactory
+            .selectFrom(activityJpaEntity)
+            .orderBy(orders.toArray(OrderSpecifier[]::new))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+
+        return checkLastPage(pageable, results)
+            .map(ActivityJpaEntity::toModel);
+    }
+
+    // 무한스크롤 처리
+    private Slice<ActivityJpaEntity> checkLastPage(Pageable pageable,
+        List<ActivityJpaEntity> results) {
+
+        boolean hasNext = false;
+        if (results.size() > pageable.getPageSize()) {
+            hasNext = true;
+            results.remove(pageable.getPageSize());
+        }
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
+
+    // 정렬 기준에 맞는 OrderSpecifier 생성
+    private List<OrderSpecifier> getAllOrderSpecifiers(Pageable pageable) {
+        List<OrderSpecifier> orders = new ArrayList<>();
+
+        if (!isEmpty(pageable.getSort())) {
+            for (Sort.Order order : pageable.getSort()) {
+                Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+                switch (order.getProperty()) {
+                    case "id":
+                        OrderSpecifier<?> orderId = QueryDslUtil.getSortedColumn(direction,
+                            activityJpaEntity, "id");
+                        orders.add(orderId);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+        return orders;
+    }
+}

--- a/src/main/java/com/gamsa/activity/repository/ActivityJpaRepository.java
+++ b/src/main/java/com/gamsa/activity/repository/ActivityJpaRepository.java
@@ -3,6 +3,7 @@ package com.gamsa.activity.repository;
 import com.gamsa.activity.entity.ActivityJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ActivityJpaRepository extends JpaRepository<ActivityJpaEntity, Long> {
+public interface ActivityJpaRepository extends JpaRepository<ActivityJpaEntity, Long>,
+    ActivityCustomRepository {
 
 }

--- a/src/main/java/com/gamsa/activity/repository/ActivityRepositoryImpl.java
+++ b/src/main/java/com/gamsa/activity/repository/ActivityRepositoryImpl.java
@@ -2,9 +2,10 @@ package com.gamsa.activity.repository;
 
 import com.gamsa.activity.domain.Activity;
 import com.gamsa.activity.entity.ActivityJpaEntity;
-import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -19,10 +20,8 @@ public class ActivityRepositoryImpl implements ActivityRepository {
     }
 
     @Override
-    public List<Activity> findAll() {
-        return activityJpaRepository.findAll()
-            .stream().map(ActivityJpaEntity::toModel)
-            .toList();
+    public Slice<Activity> findSlice(Pageable pageable) {
+        return activityJpaRepository.findSlice(pageable);
     }
 
     @Override

--- a/src/main/java/com/gamsa/activity/service/ActivityService.java
+++ b/src/main/java/com/gamsa/activity/service/ActivityService.java
@@ -7,8 +7,9 @@ import com.gamsa.activity.dto.ActivitySaveRequest;
 import com.gamsa.activity.exception.ActivityCustomException;
 import com.gamsa.activity.repository.ActivityRepository;
 import com.gamsa.common.constant.ErrorCode;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -25,11 +26,9 @@ public class ActivityService {
         activityRepository.save(saveRequest.toModel());
     }
 
-    public List<ActivityFindAllResponse> findAll() {
-        List<Activity> activities = activityRepository.findAll();
-        return activities.stream()
-            .map(ActivityFindAllResponse::from)
-            .toList();
+    public Slice<ActivityFindAllResponse> findAll(Pageable pageable) {
+        Slice<Activity> activities = activityRepository.findSlice(pageable);
+        return activities.map(ActivityFindAllResponse::from);
     }
 
     public ActivityDetailResponse findById(Long activityId) {

--- a/src/main/java/com/gamsa/activity/service/ActivityService.java
+++ b/src/main/java/com/gamsa/activity/service/ActivityService.java
@@ -1,12 +1,12 @@
 package com.gamsa.activity.service;
 
+import com.gamsa.activity.constant.ActivityErrorCode;
 import com.gamsa.activity.domain.Activity;
 import com.gamsa.activity.dto.ActivityDetailResponse;
 import com.gamsa.activity.dto.ActivityFindAllResponse;
 import com.gamsa.activity.dto.ActivitySaveRequest;
 import com.gamsa.activity.exception.ActivityCustomException;
 import com.gamsa.activity.repository.ActivityRepository;
-import com.gamsa.common.constant.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -21,7 +21,7 @@ public class ActivityService {
     public void save(ActivitySaveRequest saveRequest) {
         activityRepository.findById(saveRequest.getActId())
             .ifPresent(activity -> {
-                throw new ActivityCustomException(ErrorCode.ACTIVITY_ALREADY_EXISTS);
+                throw new ActivityCustomException(ActivityErrorCode.ACTIVITY_ALREADY_EXISTS);
             });
         activityRepository.save(saveRequest.toModel());
     }
@@ -33,7 +33,7 @@ public class ActivityService {
 
     public ActivityDetailResponse findById(Long activityId) {
         Activity activity = activityRepository.findById(activityId)
-            .orElseThrow(() -> new ActivityCustomException(ErrorCode.ACTIVITY_NOT_EXISTS));
+            .orElseThrow(() -> new ActivityCustomException(ActivityErrorCode.ACTIVITY_NOT_EXISTS));
         return ActivityDetailResponse.from(activity);
     }
 }

--- a/src/main/java/com/gamsa/common/config/QueryDslConfig.java
+++ b/src/main/java/com/gamsa/common/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.gamsa.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/gamsa/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gamsa/common/exception/GlobalExceptionHandler.java
@@ -14,7 +14,7 @@ public class GlobalExceptionHandler {
     private ResponseEntity<?> ActivityCustomExceptionHandler(ActivityCustomException e) {
         log.error(String.valueOf(e.getStackTrace()[0]));
         return ResponseEntity
-            .status(e.getErrorCode().getStatus())
-            .body(e.getErrorCode().getMsg());
+            .status(e.getActivityErrorCode().getStatus())
+            .body(e.getActivityErrorCode().getMsg());
     }
 }

--- a/src/main/java/com/gamsa/common/utils/QueryDslUtil.java
+++ b/src/main/java/com/gamsa/common/utils/QueryDslUtil.java
@@ -1,0 +1,14 @@
+package com.gamsa.common.utils;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.Expressions;
+
+public class QueryDslUtil {
+
+    public static OrderSpecifier<?> getSortedColumn(Order order, Path<?> parent, String fieldName) {
+        Path<Object> fieldPath = Expressions.path(Object.class, parent, fieldName);
+        return new OrderSpecifier(order, fieldPath);
+    }
+}

--- a/src/test/java/com/gamsa/activity/repository/ActivityJpaRepositoryTest.java
+++ b/src/test/java/com/gamsa/activity/repository/ActivityJpaRepositoryTest.java
@@ -2,14 +2,22 @@ package com.gamsa.activity.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.gamsa.activity.domain.Activity;
 import com.gamsa.activity.entity.ActivityJpaEntity;
+import com.gamsa.common.config.TestConfig;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort.Direction;
 
 @DataJpaTest
+@Import(TestConfig.class)
 class ActivityJpaRepositoryTest {
 
     @Autowired
@@ -34,7 +42,26 @@ class ActivityJpaRepositoryTest {
         .actPhone("032-577-3026")
         .url("https://...")
         .build();
-
+    private final ActivityJpaEntity jpaEntity2 = ActivityJpaEntity.builder()
+        .actId(2L)
+        .actTitle("어린이놀이안전관리 청소")
+        .actLocation("아이사랑꿈터 서구 7호점")
+        .description("봉사 내용2")
+        .noticeStartDate(LocalDateTime.of(2024, 9, 11, 0, 0))
+        .noticeEndDate(LocalDateTime.of(2024, 12, 8, 0, 0))
+        .actStartDate(LocalDateTime.of(2024, 9, 11, 0, 0))
+        .actEndDate(LocalDateTime.of(2024, 12, 8, 0, 0))
+        .actStartTime(10)
+        .actEndTime(20)
+        .recruitTotalNum(2)
+        .adultPossible(true)
+        .teenPossible(false)
+        .groupPossible(false)
+        .actWeek(0111110)
+        .actManager("홀란드")
+        .actPhone("032-111-2222")
+        .url("https://...")
+        .build();
 
     @Test
     void 새_활동_저장() {
@@ -50,11 +77,35 @@ class ActivityJpaRepositoryTest {
     void 모든_활동_리스트_반환() {
         // given
         activityJpaRepository.save(jpaEntity);
+        // when
+        Slice<Activity> result = activityJpaRepository.findSlice(PageRequest.of(0, 10));
+        // then
+        assertThat(result.getContent().size()).isEqualTo(1);
+    }
+
+    @Test
+    void 활동_상세정보_조회() {
+        // given
+        activityJpaRepository.save(jpaEntity);
+        // when
+        Optional<ActivityJpaEntity> result = activityJpaRepository.findById(1L);
+        // then
+        assertThat(result.get().getActTitle()).isEqualTo(jpaEntity.getActTitle());
+    }
+
+    @Test
+    void id로_정렬된_조회() {
+        // given
+        activityJpaRepository.save(jpaEntity);  // id = 1L
+        activityJpaRepository.save(jpaEntity2); // id = 2L
+        Pageable pageable = PageRequest.of(0, 2, Direction.DESC, "actId");
 
         // when
-        List<ActivityJpaEntity> result = activityJpaRepository.findAll();
+        Slice<Activity> result = activityJpaRepository.findSlice(pageable);
 
         // then
-        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.getSize()).isEqualTo(2);
+        assertThat(result.getContent().getFirst().getActId()).isEqualTo(2L);
+        assertThat(result.getContent().get(1).getActId()).isEqualTo(1L);
     }
 }

--- a/src/test/java/com/gamsa/activity/service/ActivityServiceTest.java
+++ b/src/test/java/com/gamsa/activity/service/ActivityServiceTest.java
@@ -10,9 +10,10 @@ import com.gamsa.activity.stub.StubEmptyActivityRepository;
 import com.gamsa.activity.stub.StubExistsActivityRepository;
 import com.gamsa.common.constant.ErrorCode;
 import java.time.LocalDateTime;
-import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 
 class ActivityServiceTest {
 
@@ -68,10 +69,10 @@ class ActivityServiceTest {
         ActivityService activityService = new ActivityService(new StubEmptyActivityRepository());
 
         // when
-        List<ActivityFindAllResponse> result = activityService.findAll();
+        Slice<ActivityFindAllResponse> result = activityService.findAll(PageRequest.of(0, 10));
 
         // then
-        assertThat(result.size()).isZero();
+        assertThat(result.getContent().size()).isZero();
     }
 
     @Test

--- a/src/test/java/com/gamsa/activity/service/ActivityServiceTest.java
+++ b/src/test/java/com/gamsa/activity/service/ActivityServiceTest.java
@@ -2,13 +2,13 @@ package com.gamsa.activity.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.gamsa.activity.constant.ActivityErrorCode;
 import com.gamsa.activity.dto.ActivityDetailResponse;
 import com.gamsa.activity.dto.ActivityFindAllResponse;
 import com.gamsa.activity.dto.ActivitySaveRequest;
 import com.gamsa.activity.exception.ActivityCustomException;
 import com.gamsa.activity.stub.StubEmptyActivityRepository;
 import com.gamsa.activity.stub.StubExistsActivityRepository;
-import com.gamsa.common.constant.ErrorCode;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -60,7 +60,7 @@ class ActivityServiceTest {
         Assertions.assertThrows(ActivityCustomException.class, () -> {
             // when
             activityService.save(saveRequest);
-        }, ErrorCode.ACTIVITY_ALREADY_EXISTS.getMsg());
+        }, ActivityErrorCode.ACTIVITY_ALREADY_EXISTS.getMsg());
     }
 
     @Test
@@ -96,6 +96,6 @@ class ActivityServiceTest {
         Assertions.assertThrows(ActivityCustomException.class, () -> {
             // when
             activityService.findById(1L);
-        }, ErrorCode.ACTIVITY_NOT_EXISTS.getMsg());
+        }, ActivityErrorCode.ACTIVITY_NOT_EXISTS.getMsg());
     }
 }

--- a/src/test/java/com/gamsa/activity/stub/StubEmptyActivityRepository.java
+++ b/src/test/java/com/gamsa/activity/stub/StubEmptyActivityRepository.java
@@ -4,6 +4,9 @@ import com.gamsa.activity.domain.Activity;
 import com.gamsa.activity.repository.ActivityRepository;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 public class StubEmptyActivityRepository implements ActivityRepository {
 
@@ -13,8 +16,8 @@ public class StubEmptyActivityRepository implements ActivityRepository {
     }
 
     @Override
-    public List<Activity> findAll() {
-        return List.of();
+    public Slice<Activity> findSlice(Pageable pageable) {
+        return new SliceImpl<>(List.of());
     }
 
     @Override

--- a/src/test/java/com/gamsa/activity/stub/StubExistsActivityRepository.java
+++ b/src/test/java/com/gamsa/activity/stub/StubExistsActivityRepository.java
@@ -5,6 +5,9 @@ import com.gamsa.activity.repository.ActivityRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 public class StubExistsActivityRepository implements ActivityRepository {
 
@@ -35,8 +38,8 @@ public class StubExistsActivityRepository implements ActivityRepository {
     }
 
     @Override
-    public List<Activity> findAll() {
-        return List.of();
+    public Slice<Activity> findSlice(Pageable pageable) {
+        return new SliceImpl<>(List.of(activity));
     }
 
     @Override

--- a/src/test/java/com/gamsa/common/config/TestConfig.java
+++ b/src/test/java/com/gamsa/common/config/TestConfig.java
@@ -1,0 +1,19 @@
+package com.gamsa.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

- 구현했던 봉사활동 조회 기능에 정렬 + 무한스크롤 기능 추가.
- 현재는 actId로만 정렬 가능하도록 했으나, 추후에 추가할 예정.
- 단위 테스트 코드 추가하였음.
- 무한 스크롤 구현 시 QueryDSL을 사용하여 구현하였으며, CustomRepository 패턴을 사용하여 기존 JpaRepository와 결합하였음 .(querydsl custom repository 키워드로 관련내용 서치 가능)
- common.costant에 있던 상수패키지를 activity 도메인 패키지로 이전하였음.
- 봉사활동 테이블의 id 컬럼명을 actId로 변경하였음.

## 🔧 앞으로의 과제

- 정렬 기준 구체화한 뒤에 해당 기능 추가해야할듯.
- 일단 구현이 쉬운 offset 페이지네이션으로 구현하였으나, 추후 성능을 고려한다면 no-offset 페이지네이션을 도입해야할 수도 있음.

## 📝 리뷰어에게
- QueryDSL과 JpaRepository 결합을 위한 CustomRepository 인터페이스를 만들어 적용하였습니다.
- 해당 부분 구조를 중점으로 리뷰 부탁드립니다.

## ✅ 해결 이슈

- resolved #18 
