### PR TITLE
feat: 봉사 분야 기능, 봉사 조회 필터링 기능 추가

### DIFF
--- a/src/main/java/com/gamsa/activity/constant/Category.java
+++ b/src/main/java/com/gamsa/activity/constant/Category.java
@@ -1,0 +1,18 @@
+package com.gamsa.activity.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Category {
+    LIFE_SUPPORT_AND_HOUSING_IMPROVEMENT("생활지원 및 주거환경 개선"),
+    EDUCATION_AND_MENTORING("교육 및 멘토링"),
+    ADMINISTRATIVE_AND_OFFICE_SUPPORT("행정 및 사무지원"),
+    CULTURE_ENVIRONMENT_AND_INTERNATIONAL_COOPERATION("문화, 환경 및 국제협력 활동"),
+    HEALTHCARE_AND_PUBLIC_WELFARE("보건의료 및 공익활동"),
+    COUNSELING_AND_VOLUNTEER_TRAINING("상담 및 자원봉사 교육"),
+    OTHER_ACTIVITIES("기타 활동");
+
+    private final String name;
+}

--- a/src/main/java/com/gamsa/activity/constant/CategoryConverter.java
+++ b/src/main/java/com/gamsa/activity/constant/CategoryConverter.java
@@ -1,0 +1,28 @@
+package com.gamsa.activity.constant;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.stream.Stream;
+
+@Converter
+public class CategoryConverter implements AttributeConverter<Category, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Category category) {
+        if (category == null) {
+            return null;
+        }
+        return category.getName();
+    }
+
+    @Override
+    public Category convertToEntityAttribute(String name) {
+        if (name == null) {
+            return null;
+        }
+        return Stream.of(Category.values())
+            .filter(category -> category.getName().equals(name))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리 접근."));
+    }
+}

--- a/src/main/java/com/gamsa/activity/controller/ActivityController.java
+++ b/src/main/java/com/gamsa/activity/controller/ActivityController.java
@@ -1,6 +1,8 @@
 package com.gamsa.activity.controller;
 
+import com.gamsa.activity.constant.Category;
 import com.gamsa.activity.dto.ActivityDetailResponse;
+import com.gamsa.activity.dto.ActivityFilterRequest;
 import com.gamsa.activity.dto.ActivityFindSliceResponse;
 import com.gamsa.activity.dto.ActivitySaveRequest;
 import com.gamsa.activity.service.ActivityService;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -24,8 +27,15 @@ public class ActivityController {
     private final ActivityService activityService;
 
     @GetMapping
-    public Slice<ActivityFindSliceResponse> findSlice(Pageable pageable) {
-        return activityService.findSlice(pageable);
+    public Slice<ActivityFindSliceResponse> findSlice(
+        @RequestParam(required = false) Category category,
+        @RequestParam(defaultValue = "false") boolean teenPossibleOnly,
+        @RequestParam(defaultValue = "false") boolean deadlineEndOnly,
+        Pageable pageable) {
+
+        ActivityFilterRequest request = new ActivityFilterRequest(category, teenPossibleOnly,
+            deadlineEndOnly);
+        return activityService.findSlice(request, pageable);
     }
 
     @GetMapping("{activity-id}")

--- a/src/main/java/com/gamsa/activity/controller/ActivityController.java
+++ b/src/main/java/com/gamsa/activity/controller/ActivityController.java
@@ -30,11 +30,11 @@ public class ActivityController {
     public Slice<ActivityFindSliceResponse> findSlice(
         @RequestParam(required = false) Category category,
         @RequestParam(defaultValue = "false") boolean teenPossibleOnly,
-        @RequestParam(defaultValue = "false") boolean deadlineEndOnly,
+        @RequestParam(defaultValue = "false") boolean beforeDeadlineOnly,
         Pageable pageable) {
 
         ActivityFilterRequest request = new ActivityFilterRequest(category, teenPossibleOnly,
-            deadlineEndOnly);
+            beforeDeadlineOnly);
         return activityService.findSlice(request, pageable);
     }
 

--- a/src/main/java/com/gamsa/activity/domain/Activity.java
+++ b/src/main/java/com/gamsa/activity/domain/Activity.java
@@ -1,5 +1,6 @@
 package com.gamsa.activity.domain;
 
+import com.gamsa.activity.constant.Category;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,4 +29,5 @@ public class Activity {
     private String actManager;
     private String actPhone;
     private String url;
+    private Category category;
 }

--- a/src/main/java/com/gamsa/activity/domain/Activity.java
+++ b/src/main/java/com/gamsa/activity/domain/Activity.java
@@ -1,10 +1,13 @@
 package com.gamsa.activity.domain;
 
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
+@AllArgsConstructor
 public class Activity {
 
     private Long actId;
@@ -25,31 +28,4 @@ public class Activity {
     private String actManager;
     private String actPhone;
     private String url;
-
-    @Builder
-    public Activity(Long actId, String actTitle, String actLocation, String description,
-        LocalDateTime noticeStartDate, LocalDateTime noticeEndDate,
-        LocalDateTime actStartDate, LocalDateTime actEndDate,
-        int actStartTime, int actEndTime, int recruitTotalNum, boolean adultPossible,
-        boolean teenPossible, boolean groupPossible,
-        int actWeek, String actManager, String actPhone, String url) {
-        this.actId = actId;
-        this.actTitle = actTitle;
-        this.actLocation = actLocation;
-        this.description = description;
-        this.noticeStartDate = noticeStartDate;
-        this.noticeEndDate = noticeEndDate;
-        this.actStartDate = actStartDate;
-        this.actEndDate = actEndDate;
-        this.actStartTime = actStartTime;
-        this.actEndTime = actEndTime;
-        this.recruitTotalNum = recruitTotalNum;
-        this.adultPossible = adultPossible;
-        this.teenPossible = teenPossible;
-        this.groupPossible = groupPossible;
-        this.actWeek = actWeek;
-        this.actManager = actManager;
-        this.actPhone = actPhone;
-        this.url = url;
-    }
 }

--- a/src/main/java/com/gamsa/activity/dto/ActivityDetailResponse.java
+++ b/src/main/java/com/gamsa/activity/dto/ActivityDetailResponse.java
@@ -1,6 +1,7 @@
 package com.gamsa.activity.dto;
 
 
+import com.gamsa.activity.constant.Category;
 import com.gamsa.activity.domain.Activity;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -30,6 +31,7 @@ public class ActivityDetailResponse {
     private final String actManager;
     private final String actPhone;
     private final String url;
+    private final Category category;
 
     public static ActivityDetailResponse from(Activity activity) {
         return ActivityDetailResponse.builder()
@@ -51,6 +53,7 @@ public class ActivityDetailResponse {
             .actManager(activity.getActManager())
             .actPhone(activity.getActPhone())
             .url(activity.getUrl())
+            .category(activity.getCategory())
             .build();
     }
 }

--- a/src/main/java/com/gamsa/activity/dto/ActivityFilterRequest.java
+++ b/src/main/java/com/gamsa/activity/dto/ActivityFilterRequest.java
@@ -16,6 +16,6 @@ public class ActivityFilterRequest {
     // 청소년 가능한 것만
     private final boolean teenPossibleOnly;
 
-    // 마감된 활동만
-    private final boolean deadlineEndOnly;
+    // 마감되지 않은 활동만
+    private final boolean beforeDeadlineOnly;
 }

--- a/src/main/java/com/gamsa/activity/dto/ActivityFilterRequest.java
+++ b/src/main/java/com/gamsa/activity/dto/ActivityFilterRequest.java
@@ -1,0 +1,21 @@
+package com.gamsa.activity.dto;
+
+import com.gamsa.activity.constant.Category;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ActivityFilterRequest {
+
+    // 카테고리
+    private final Category category;
+
+    // Todo 지역
+
+    // 청소년 가능한 것만
+    private final boolean teenPossibleOnly;
+
+    // 마감된 활동만
+    private final boolean deadlineEndOnly;
+}

--- a/src/main/java/com/gamsa/activity/dto/ActivityFindSliceResponse.java
+++ b/src/main/java/com/gamsa/activity/dto/ActivityFindSliceResponse.java
@@ -1,5 +1,6 @@
 package com.gamsa.activity.dto;
 
+import com.gamsa.activity.constant.Category;
 import com.gamsa.activity.domain.Activity;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -21,6 +22,7 @@ public class ActivityFindSliceResponse {
     private final int actStartTime;
     private final int actEndTime;
     private final int recruitTotalNum;
+    private final Category category;
 
     public static ActivityFindSliceResponse from(Activity activity) {
         return ActivityFindSliceResponse.builder()
@@ -34,6 +36,7 @@ public class ActivityFindSliceResponse {
             .actStartTime(activity.getActStartTime())
             .actEndTime(activity.getActEndTime())
             .recruitTotalNum(activity.getRecruitTotalNum())
+            .category(activity.getCategory())
             .build();
     }
 }

--- a/src/main/java/com/gamsa/activity/dto/ActivitySaveRequest.java
+++ b/src/main/java/com/gamsa/activity/dto/ActivitySaveRequest.java
@@ -1,5 +1,6 @@
 package com.gamsa.activity.dto;
 
+import com.gamsa.activity.constant.Category;
 import com.gamsa.activity.domain.Activity;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -29,6 +30,7 @@ public class ActivitySaveRequest {
     private final String actManager;
     private final String actPhone;
     private final String url;
+    private final Category category;
 
     public Activity toModel() {
         return Activity.builder()
@@ -50,6 +52,7 @@ public class ActivitySaveRequest {
             .actManager(actManager)
             .actPhone(actPhone)
             .url(url)
+            .category(category)
             .build();
     }
 }

--- a/src/main/java/com/gamsa/activity/entity/ActivityJpaEntity.java
+++ b/src/main/java/com/gamsa/activity/entity/ActivityJpaEntity.java
@@ -1,8 +1,11 @@
 package com.gamsa.activity.entity;
 
+import com.gamsa.activity.constant.Category;
+import com.gamsa.activity.constant.CategoryConverter;
 import com.gamsa.activity.domain.Activity;
 import com.gamsa.common.entity.BaseEntity;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
@@ -85,6 +88,10 @@ public class ActivityJpaEntity extends BaseEntity {
     @Column(name = "url", length = 255)
     private String url;
 
+    @Convert(converter = CategoryConverter.class)
+    @Column(name = "category", length = 255)
+    private Category category;
+
     public static ActivityJpaEntity from(Activity activity) {
         return ActivityJpaEntity.builder()
             .actId(activity.getActId())
@@ -105,6 +112,7 @@ public class ActivityJpaEntity extends BaseEntity {
             .actManager(activity.getActManager())
             .actPhone(activity.getActPhone())
             .url(activity.getUrl())
+            .category(activity.getCategory())
             .build();
     }
 
@@ -128,6 +136,7 @@ public class ActivityJpaEntity extends BaseEntity {
             .actManager(actManager)
             .actPhone(actPhone)
             .url(url)
+            .category(category)
             .build();
     }
 

--- a/src/main/java/com/gamsa/activity/repository/ActivityCustomRepository.java
+++ b/src/main/java/com/gamsa/activity/repository/ActivityCustomRepository.java
@@ -1,11 +1,12 @@
 package com.gamsa.activity.repository;
 
+import com.gamsa.activity.dto.ActivityFilterRequest;
 import com.gamsa.activity.entity.ActivityJpaEntity;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface ActivityCustomRepository {
 
-    Slice<ActivityJpaEntity> findSlice(Pageable pageable);
+    Slice<ActivityJpaEntity> findSlice(ActivityFilterRequest request, Pageable pageable);
 
 }

--- a/src/main/java/com/gamsa/activity/repository/ActivityCustomRepositoryImpl.java
+++ b/src/main/java/com/gamsa/activity/repository/ActivityCustomRepositoryImpl.java
@@ -2,7 +2,9 @@ package com.gamsa.activity.repository;
 
 import static com.gamsa.activity.entity.QActivityJpaEntity.activityJpaEntity;
 
+import com.gamsa.activity.dto.ActivityFilterRequest;
 import com.gamsa.activity.entity.ActivityJpaEntity;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.PathBuilder;
@@ -20,11 +22,13 @@ public class ActivityCustomRepositoryImpl implements ActivityCustomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Slice<ActivityJpaEntity> findSlice(Pageable pageable) {
+    public Slice<ActivityJpaEntity> findSlice(ActivityFilterRequest request, Pageable pageable) {
         List<OrderSpecifier> orders = getAllOrderSpecifiers(pageable);
+        BooleanBuilder filterBuilder = ActivityFilterBuilder.createFilter(request);
 
         List<ActivityJpaEntity> results = jpaQueryFactory
             .selectFrom(activityJpaEntity)
+            .where(filterBuilder)
             .orderBy(orders.toArray(OrderSpecifier[]::new))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize() + 1)

--- a/src/main/java/com/gamsa/activity/repository/ActivityFilterBuilder.java
+++ b/src/main/java/com/gamsa/activity/repository/ActivityFilterBuilder.java
@@ -1,0 +1,39 @@
+package com.gamsa.activity.repository;
+
+import static com.gamsa.activity.entity.QActivityJpaEntity.activityJpaEntity;
+
+import com.gamsa.activity.constant.Category;
+import com.gamsa.activity.dto.ActivityFilterRequest;
+import com.querydsl.core.BooleanBuilder;
+import java.time.LocalDateTime;
+
+public class ActivityFilterBuilder {
+
+    public static BooleanBuilder createFilter(ActivityFilterRequest request) {
+        BooleanBuilder filterBuilder = new BooleanBuilder();
+
+        eqCategory(filterBuilder, request.getCategory());
+        isTeenPossibleOnly(filterBuilder, request.isTeenPossibleOnly());
+        isDeadlineEndOnly(filterBuilder, request.isDeadlineEndOnly());
+
+        return filterBuilder;
+    }
+
+    public static void eqCategory(BooleanBuilder filterBuilder, Category category) {
+        if (category != null) {
+            filterBuilder.and(activityJpaEntity.category.eq(category));
+        }
+    }
+
+    public static void isTeenPossibleOnly(BooleanBuilder filterBuilder, boolean teenPossibleOnly) {
+        if (teenPossibleOnly) {
+            filterBuilder.and(activityJpaEntity.teenPossible.isTrue());
+        }
+    }
+
+    public static void isDeadlineEndOnly(BooleanBuilder filterBuilder, boolean deadlineEndOnly) {
+        if (deadlineEndOnly) {
+            filterBuilder.and(activityJpaEntity.noticeEndDate.before(LocalDateTime.now()));
+        }
+    }
+}

--- a/src/main/java/com/gamsa/activity/repository/ActivityFilterBuilder.java
+++ b/src/main/java/com/gamsa/activity/repository/ActivityFilterBuilder.java
@@ -14,7 +14,7 @@ public class ActivityFilterBuilder {
 
         eqCategory(filterBuilder, request.getCategory());
         isTeenPossibleOnly(filterBuilder, request.isTeenPossibleOnly());
-        isDeadlineEndOnly(filterBuilder, request.isDeadlineEndOnly());
+        isDeadlineEndOnly(filterBuilder, request.isBeforeDeadlineOnly());
 
         return filterBuilder;
     }
@@ -31,9 +31,9 @@ public class ActivityFilterBuilder {
         }
     }
 
-    public static void isDeadlineEndOnly(BooleanBuilder filterBuilder, boolean deadlineEndOnly) {
-        if (deadlineEndOnly) {
-            filterBuilder.and(activityJpaEntity.noticeEndDate.before(LocalDateTime.now()));
+    public static void isDeadlineEndOnly(BooleanBuilder filterBuilder, boolean beforeDeadlineOnly) {
+        if (beforeDeadlineOnly) {
+            filterBuilder.and(activityJpaEntity.noticeEndDate.after(LocalDateTime.now()));
         }
     }
 }

--- a/src/main/java/com/gamsa/activity/repository/ActivityRepository.java
+++ b/src/main/java/com/gamsa/activity/repository/ActivityRepository.java
@@ -1,6 +1,7 @@
 package com.gamsa.activity.repository;
 
 import com.gamsa.activity.domain.Activity;
+import com.gamsa.activity.dto.ActivityFilterRequest;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -9,7 +10,7 @@ public interface ActivityRepository {
 
     void save(Activity activity);
 
-    Slice<Activity> findSlice(Pageable pageable);
+    Slice<Activity> findSlice(ActivityFilterRequest request, Pageable pageable);
 
     Optional<Activity> findById(Long activityId);
 }

--- a/src/main/java/com/gamsa/activity/repository/ActivityRepositoryImpl.java
+++ b/src/main/java/com/gamsa/activity/repository/ActivityRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.gamsa.activity.repository;
 
 import com.gamsa.activity.domain.Activity;
+import com.gamsa.activity.dto.ActivityFilterRequest;
 import com.gamsa.activity.entity.ActivityJpaEntity;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -20,8 +21,8 @@ public class ActivityRepositoryImpl implements ActivityRepository {
     }
 
     @Override
-    public Slice<Activity> findSlice(Pageable pageable) {
-        return activityJpaRepository.findSlice(pageable)
+    public Slice<Activity> findSlice(ActivityFilterRequest request, Pageable pageable) {
+        return activityJpaRepository.findSlice(request, pageable)
             .map(ActivityJpaEntity::toModel);
     }
 

--- a/src/main/java/com/gamsa/activity/service/ActivityService.java
+++ b/src/main/java/com/gamsa/activity/service/ActivityService.java
@@ -3,6 +3,7 @@ package com.gamsa.activity.service;
 import com.gamsa.activity.constant.ActivityErrorCode;
 import com.gamsa.activity.domain.Activity;
 import com.gamsa.activity.dto.ActivityDetailResponse;
+import com.gamsa.activity.dto.ActivityFilterRequest;
 import com.gamsa.activity.dto.ActivityFindSliceResponse;
 import com.gamsa.activity.dto.ActivitySaveRequest;
 import com.gamsa.activity.exception.ActivityException;
@@ -26,8 +27,9 @@ public class ActivityService {
         activityRepository.save(saveRequest.toModel());
     }
 
-    public Slice<ActivityFindSliceResponse> findSlice(Pageable pageable) {
-        Slice<Activity> activities = activityRepository.findSlice(pageable);
+    public Slice<ActivityFindSliceResponse> findSlice(ActivityFilterRequest request,
+        Pageable pageable) {
+        Slice<Activity> activities = activityRepository.findSlice(request, pageable);
         return activities.map(ActivityFindSliceResponse::from);
     }
 

--- a/src/main/java/com/gamsa/auth/SecurityConfig.java
+++ b/src/main/java/com/gamsa/auth/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -15,6 +16,8 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
+            .headers(headerConfig -> headerConfig.frameOptions(
+                HeadersConfigurer.FrameOptionsConfig::sameOrigin))
             .authorizeHttpRequests(authorizeRequest -> {
                 authorizeRequest
                     .anyRequest().permitAll();

--- a/src/test/java/com/gamsa/activity/entity/ActivityJpaEntityTest.java
+++ b/src/test/java/com/gamsa/activity/entity/ActivityJpaEntityTest.java
@@ -2,6 +2,7 @@ package com.gamsa.activity.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.gamsa.activity.constant.Category;
 import com.gamsa.activity.domain.Activity;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,7 @@ class ActivityJpaEntityTest {
             .actWeek(0111110)
             .actManager("윤순영")
             .actPhone("032-577-3026")
+            .category(Category.OTHER_ACTIVITIES)
             .url("https://...")
             .build();
 
@@ -61,6 +63,7 @@ class ActivityJpaEntityTest {
             .actManager("윤순영")
             .actPhone("032-577-3026")
             .url("https://...")
+            .category(Category.OTHER_ACTIVITIES)
             .build();
 
         // when

--- a/src/test/java/com/gamsa/activity/repository/ActivityJpaRepositoryTest.java
+++ b/src/test/java/com/gamsa/activity/repository/ActivityJpaRepositoryTest.java
@@ -15,7 +15,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort.Direction;
 
 @DataJpaTest
@@ -119,10 +118,11 @@ class ActivityJpaRepositoryTest {
         // given
         activityJpaRepository.save(jpaEntity);
         // when
-        Slice<ActivityJpaEntity> result = activityJpaRepository.findSlice(noFilterReq,
-            PageRequest.of(0, 10));
+        List<ActivityJpaEntity> content = activityJpaRepository
+            .findSlice(noFilterReq, PageRequest.of(0, 10))
+            .getContent();
         // then
-        assertThat(result.getContent().size()).isEqualTo(1);
+        assertThat(content.size()).isEqualTo(1);
     }
 
     @Test
@@ -143,12 +143,13 @@ class ActivityJpaRepositoryTest {
         Pageable pageable = PageRequest.of(0, 2, Direction.DESC, "actId");
 
         // when
-        Slice<ActivityJpaEntity> result = activityJpaRepository.findSlice(noFilterReq, pageable);
+        List<ActivityJpaEntity> content = activityJpaRepository.findSlice(noFilterReq, pageable)
+            .getContent();
 
         // then
-        assertThat(result.getSize()).isEqualTo(2);
-        assertThat(result.getContent().getFirst().getActId()).isEqualTo(2L);
-        assertThat(result.getContent().get(1).getActId()).isEqualTo(1L);
+        assertThat(content.size()).isEqualTo(2);
+        assertThat(content.getFirst().getActId()).isEqualTo(2L);
+        assertThat(content.get(1).getActId()).isEqualTo(1L);
     }
 
     @Test

--- a/src/test/java/com/gamsa/activity/repository/ActivityJpaRepositoryTest.java
+++ b/src/test/java/com/gamsa/activity/repository/ActivityJpaRepositoryTest.java
@@ -2,10 +2,12 @@ package com.gamsa.activity.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.gamsa.activity.constant.Category;
 import com.gamsa.activity.dto.ActivityFilterRequest;
 import com.gamsa.activity.entity.ActivityJpaEntity;
 import com.gamsa.common.config.TestConfig;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,15 +24,16 @@ class ActivityJpaRepositoryTest {
 
     @Autowired
     private ActivityJpaRepository activityJpaRepository;
+
     private final ActivityJpaEntity jpaEntity = ActivityJpaEntity.builder()
         .actId(1L)
         .actTitle("어린이놀이안전관리 및 놀잇감 청결유지 및 정리")
         .actLocation("아이사랑꿈터 서구 5호점")
         .description("봉사 내용")
         .noticeStartDate(LocalDateTime.of(2024, 9, 10, 0, 0))
-        .noticeEndDate(LocalDateTime.of(2024, 12, 7, 0, 0))
+        .noticeEndDate(LocalDateTime.of(2024, 9, 20, 0, 0))
         .actStartDate(LocalDateTime.of(2024, 9, 10, 0, 0))
-        .actEndDate(LocalDateTime.of(2024, 12, 7, 0, 0))
+        .actEndDate(LocalDateTime.of(2024, 9, 20, 0, 0))
         .actStartTime(13)
         .actEndTime(18)
         .recruitTotalNum(1)
@@ -41,27 +44,65 @@ class ActivityJpaRepositoryTest {
         .actManager("윤순영")
         .actPhone("032-577-3026")
         .url("https://...")
+        .category(Category.OTHER_ACTIVITIES)
         .build();
+
     private final ActivityJpaEntity jpaEntity2 = ActivityJpaEntity.builder()
         .actId(2L)
         .actTitle("어린이놀이안전관리 청소")
         .actLocation("아이사랑꿈터 서구 7호점")
         .description("봉사 내용2")
-        .noticeStartDate(LocalDateTime.of(2024, 9, 11, 0, 0))
+        .noticeStartDate(LocalDateTime.of(2024, 11, 1, 0, 0))
         .noticeEndDate(LocalDateTime.of(2024, 12, 8, 0, 0))
-        .actStartDate(LocalDateTime.of(2024, 9, 11, 0, 0))
+        .actStartDate(LocalDateTime.of(2024, 11, 1, 0, 0))
         .actEndDate(LocalDateTime.of(2024, 12, 8, 0, 0))
         .actStartTime(10)
         .actEndTime(20)
         .recruitTotalNum(2)
         .adultPossible(true)
-        .teenPossible(false)
+        .teenPossible(true)
         .groupPossible(false)
         .actWeek(0111110)
         .actManager("홀란드")
         .actPhone("032-111-2222")
         .url("https://...")
+        .category(Category.EDUCATION_AND_MENTORING)
         .build();
+
+    private final ActivityJpaEntity jpaEntity3 = ActivityJpaEntity.builder()
+        .actId(3L)
+        .actTitle("학교")
+        .actLocation("도서관")
+        .description("책 정리")
+        .noticeStartDate(LocalDateTime.of(2025, 1, 1, 0, 0))
+        .noticeEndDate(LocalDateTime.of(2025, 1, 8, 0, 0))
+        .actStartDate(LocalDateTime.of(2025, 1, 1, 0, 0))
+        .actEndDate(LocalDateTime.of(2025, 1, 8, 0, 0))
+        .actStartTime(10)
+        .actEndTime(20)
+        .recruitTotalNum(5)
+        .adultPossible(true)
+        .teenPossible(true)
+        .groupPossible(false)
+        .actWeek(0111110)
+        .actManager("사서쌤")
+        .actPhone("032-111-2222")
+        .url("https://...")
+        .category(Category.ADMINISTRATIVE_AND_OFFICE_SUPPORT)
+        .build();
+
+    // 필터링
+    private final ActivityFilterRequest noFilterReq = new ActivityFilterRequest(
+        null, false, false);
+
+    private final ActivityFilterRequest otherCategoryFilterReq = new ActivityFilterRequest(
+        Category.OTHER_ACTIVITIES, false, false);
+
+    private final ActivityFilterRequest teenPossibleFilterReq = new ActivityFilterRequest(
+        null, true, false);
+
+    private final ActivityFilterRequest beforeDeadlineFilterReq = new ActivityFilterRequest(
+        null, false, true);
 
     @Test
     void 새_활동_저장() {
@@ -76,10 +117,9 @@ class ActivityJpaRepositoryTest {
     @Test
     void 모든_활동_리스트_반환() {
         // given
-        ActivityFilterRequest filterRequest = new ActivityFilterRequest(null, false, false);
         activityJpaRepository.save(jpaEntity);
         // when
-        Slice<ActivityJpaEntity> result = activityJpaRepository.findSlice(filterRequest,
+        Slice<ActivityJpaEntity> result = activityJpaRepository.findSlice(noFilterReq,
             PageRequest.of(0, 10));
         // then
         assertThat(result.getContent().size()).isEqualTo(1);
@@ -98,17 +138,110 @@ class ActivityJpaRepositoryTest {
     @Test
     void id로_정렬된_조회() {
         // given
-        ActivityFilterRequest filterRequest = new ActivityFilterRequest(null, false, false);
         activityJpaRepository.save(jpaEntity);  // id = 1L
         activityJpaRepository.save(jpaEntity2); // id = 2L
         Pageable pageable = PageRequest.of(0, 2, Direction.DESC, "actId");
 
         // when
-        Slice<ActivityJpaEntity> result = activityJpaRepository.findSlice(filterRequest, pageable);
+        Slice<ActivityJpaEntity> result = activityJpaRepository.findSlice(noFilterReq, pageable);
 
         // then
         assertThat(result.getSize()).isEqualTo(2);
         assertThat(result.getContent().getFirst().getActId()).isEqualTo(2L);
         assertThat(result.getContent().get(1).getActId()).isEqualTo(1L);
+    }
+
+    @Test
+    void 마감_날짜_오름차순_정렬_조회() {
+        // given
+        activityJpaRepository.save(jpaEntity);
+        activityJpaRepository.save(jpaEntity2);
+        activityJpaRepository.save(jpaEntity3);
+        Pageable pageable = PageRequest
+            .of(0, 3, Direction.ASC, "noticeEndDate");
+
+        // when
+        List<ActivityJpaEntity> content = activityJpaRepository.findSlice(noFilterReq, pageable)
+            .getContent();
+
+        // then
+        assertThat(content.size()).isEqualTo(3);
+        assertThat(content.get(0).getNoticeEndDate().isBefore(content.get(1).getNoticeEndDate()))
+            .isTrue();
+        assertThat(content.get(1).getNoticeEndDate().isBefore(content.get(2).getNoticeEndDate()))
+            .isTrue();
+    }
+
+    @Test
+    void 마감된_공고중_마감_날짜_가까운순_정렬_조회() {
+        // given
+        LocalDateTime date = LocalDateTime.of(2024, 10, 1, 0, 0);
+        activityJpaRepository.save(jpaEntity);
+        activityJpaRepository.save(jpaEntity2);
+        activityJpaRepository.save(jpaEntity3);
+        Pageable pageable = PageRequest
+            .of(0, 3, Direction.ASC, "noticeEndDate");
+
+        // when
+        List<ActivityJpaEntity> content1 = activityJpaRepository
+            .findSlice(noFilterReq, pageable).getContent();
+        List<ActivityJpaEntity> content2 = activityJpaRepository
+            .findSlice(beforeDeadlineFilterReq, pageable).getContent();
+
+        // then
+        assertThat(content1.size()).isEqualTo(3);   // 필터링 X
+        assertThat(content2.size()).isEqualTo(2);   // 필터링 O
+        assertThat(content2.getFirst().getNoticeEndDate()
+            .isBefore(content2.getLast().getNoticeEndDate()))
+            .isTrue();
+    }
+
+    @Test
+    void 카테고리로_필터링_조회() {
+        // given
+        activityJpaRepository.save(jpaEntity);
+        activityJpaRepository.save(jpaEntity2);
+        Pageable pageable = PageRequest.of(0, 2, Direction.ASC, "actId");
+
+        // when
+        List<ActivityJpaEntity> content = activityJpaRepository.findSlice(otherCategoryFilterReq,
+            pageable).getContent();
+
+        // then
+        assertThat(content.size()).isEqualTo(1);
+        assertThat(content.getFirst().getCategory()).isEqualTo(Category.OTHER_ACTIVITIES);
+    }
+
+    @Test
+    void 청소년_가능여부_필터링_조회() {
+        // given
+        activityJpaRepository.save(jpaEntity);
+        activityJpaRepository.save(jpaEntity2);
+        Pageable pageable = PageRequest.of(0, 2, Direction.ASC, "actId");
+
+        // when
+        List<ActivityJpaEntity> content = activityJpaRepository.findSlice(teenPossibleFilterReq,
+            pageable).getContent();
+
+        // then
+        assertThat(content.size()).isEqualTo(1);
+        assertThat(content.getFirst().isTeenPossible()).isTrue();
+    }
+
+    @Test
+    void 마감되지_않은_활동만_필터링_조회() {
+        // given
+        LocalDateTime date = LocalDateTime.of(2024, 10, 1, 0, 0);
+        activityJpaRepository.save(jpaEntity);
+        activityJpaRepository.save(jpaEntity2);
+        Pageable pageable = PageRequest.of(0, 2, Direction.ASC, "actId");
+
+        // when
+        List<ActivityJpaEntity> content = activityJpaRepository.findSlice(beforeDeadlineFilterReq,
+            pageable).getContent();
+
+        // then
+        assertThat(content.size()).isEqualTo(1);
+        assertThat(content.getFirst().getNoticeEndDate().isAfter(date)).isTrue();
     }
 }

--- a/src/test/java/com/gamsa/activity/repository/ActivityJpaRepositoryTest.java
+++ b/src/test/java/com/gamsa/activity/repository/ActivityJpaRepositoryTest.java
@@ -2,6 +2,7 @@ package com.gamsa.activity.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.gamsa.activity.dto.ActivityFilterRequest;
 import com.gamsa.activity.entity.ActivityJpaEntity;
 import com.gamsa.common.config.TestConfig;
 import java.time.LocalDateTime;
@@ -75,9 +76,11 @@ class ActivityJpaRepositoryTest {
     @Test
     void 모든_활동_리스트_반환() {
         // given
+        ActivityFilterRequest filterRequest = new ActivityFilterRequest(null, false, false);
         activityJpaRepository.save(jpaEntity);
         // when
-        Slice<ActivityJpaEntity> result = activityJpaRepository.findSlice(PageRequest.of(0, 10));
+        Slice<ActivityJpaEntity> result = activityJpaRepository.findSlice(filterRequest,
+            PageRequest.of(0, 10));
         // then
         assertThat(result.getContent().size()).isEqualTo(1);
     }
@@ -95,12 +98,13 @@ class ActivityJpaRepositoryTest {
     @Test
     void id로_정렬된_조회() {
         // given
+        ActivityFilterRequest filterRequest = new ActivityFilterRequest(null, false, false);
         activityJpaRepository.save(jpaEntity);  // id = 1L
         activityJpaRepository.save(jpaEntity2); // id = 2L
         Pageable pageable = PageRequest.of(0, 2, Direction.DESC, "actId");
 
         // when
-        Slice<ActivityJpaEntity> result = activityJpaRepository.findSlice(pageable);
+        Slice<ActivityJpaEntity> result = activityJpaRepository.findSlice(filterRequest, pageable);
 
         // then
         assertThat(result.getSize()).isEqualTo(2);

--- a/src/test/java/com/gamsa/activity/service/ActivityServiceTest.java
+++ b/src/test/java/com/gamsa/activity/service/ActivityServiceTest.java
@@ -69,7 +69,8 @@ class ActivityServiceTest {
         ActivityService activityService = new ActivityService(new StubEmptyActivityRepository());
 
         // when
-        Slice<ActivityFindSliceResponse> result = activityService.findSlice(PageRequest.of(0, 10));
+        Slice<ActivityFindSliceResponse> result = activityService.findSlice(null,
+            PageRequest.of(0, 10));
 
         // then
         assertThat(result.getContent().size()).isZero();

--- a/src/test/java/com/gamsa/activity/service/ActivityServiceTest.java
+++ b/src/test/java/com/gamsa/activity/service/ActivityServiceTest.java
@@ -3,6 +3,7 @@ package com.gamsa.activity.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.gamsa.activity.constant.ActivityErrorCode;
+import com.gamsa.activity.constant.Category;
 import com.gamsa.activity.dto.ActivityDetailResponse;
 import com.gamsa.activity.dto.ActivityFindSliceResponse;
 import com.gamsa.activity.dto.ActivitySaveRequest;
@@ -36,6 +37,7 @@ class ActivityServiceTest {
         .actManager("윤순영")
         .actPhone("032-577-3026")
         .url("https://...")
+        .category(Category.OTHER_ACTIVITIES)
         .build();
 
     @Test

--- a/src/test/java/com/gamsa/activity/stub/StubEmptyActivityRepository.java
+++ b/src/test/java/com/gamsa/activity/stub/StubEmptyActivityRepository.java
@@ -1,6 +1,7 @@
 package com.gamsa.activity.stub;
 
 import com.gamsa.activity.domain.Activity;
+import com.gamsa.activity.dto.ActivityFilterRequest;
 import com.gamsa.activity.repository.ActivityRepository;
 import java.util.List;
 import java.util.Optional;
@@ -16,7 +17,7 @@ public class StubEmptyActivityRepository implements ActivityRepository {
     }
 
     @Override
-    public Slice<Activity> findSlice(Pageable pageable) {
+    public Slice<Activity> findSlice(ActivityFilterRequest request, Pageable pageable) {
         return new SliceImpl<>(List.of());
     }
 

--- a/src/test/java/com/gamsa/activity/stub/StubExistsActivityRepository.java
+++ b/src/test/java/com/gamsa/activity/stub/StubExistsActivityRepository.java
@@ -1,6 +1,7 @@
 package com.gamsa.activity.stub;
 
 import com.gamsa.activity.domain.Activity;
+import com.gamsa.activity.dto.ActivityFilterRequest;
 import com.gamsa.activity.repository.ActivityRepository;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -38,7 +39,7 @@ public class StubExistsActivityRepository implements ActivityRepository {
     }
 
     @Override
-    public Slice<Activity> findSlice(Pageable pageable) {
+    public Slice<Activity> findSlice(ActivityFilterRequest request, Pageable pageable) {
         return new SliceImpl<>(List.of(activity));
     }
 


### PR DESCRIPTION
## 🔎 작업 내용

- 봉사 분야 enum 컬럼 추가
- 분야 필터링 기능
- 청소년 가능 여부 필터링 기능
- 마감되지 않은 활동만 필터링 기능
- 마감 일자 가까운 순 정렬 기능
- 단위 테스트


## 🔧 앞으로의 과제

- 봉사 기관 컬럼
- 시군구 컬럼
- 시군구 필터링 기능

## 📝 리뷰어에게
- 컨트롤러에서 `@RequestParam` 으로 쿼리스트링에서 필터링 조건을 받아옵니다.
- `ActivityCustomRepository` 에 필터링 기능을 위한 `where` 절이 추가되었습니다.
- `ActivityFilterBuilder` 클래스를 통해 `BooleanFilter` 에 필터링 조건이 추가됩니다.
- 테스트 코드를 통해 필터링 기능 테스트를 확인할 수 있습니다.

## ✅ 해결 이슈

- resolved #22 
