### PR TITLE
feat: 시도, 시군구 API 및 시도, 시군구 필터링 기능 추가

### DIFF
--- a/src/main/java/com/gamsa/activity/constant/ActivityErrorCode.java
+++ b/src/main/java/com/gamsa/activity/constant/ActivityErrorCode.java
@@ -10,10 +10,12 @@ public enum ActivityErrorCode {
     // 404 Not Found : 존재하지 않는 리소스 접근
     ACTIVITY_NOT_EXISTS(404, "존재하지 않는 활동입니다."),
     INSTITUTE_NOT_EXISTS(404, "존재하지 않는 기관입니다."),
+    DISTRICT_NOT_EXISTS(404, "존재하지 않는 지역입니다."),
 
     // 409 Conflict : 요청이 현재 서버의 상태와 충돌
     ACTIVITY_ALREADY_EXISTS(409, "이미 존재하는 활동입니다."),
-    INSTITUTE_ALREADY_EXISTS(409, "이미 존재하는 기관입니다.");
+    INSTITUTE_ALREADY_EXISTS(409, "이미 존재하는 기관입니다."),
+    DISTRICT_ALREADY_EXISTS(409, "이미 존재하는 지역입니다.");
 
     private final int status;
     private final String msg;

--- a/src/main/java/com/gamsa/activity/controller/ActivityController.java
+++ b/src/main/java/com/gamsa/activity/controller/ActivityController.java
@@ -29,12 +29,20 @@ public class ActivityController {
     @GetMapping
     public Slice<ActivityFindSliceResponse> findSlice(
         @RequestParam(required = false) Category category,
+        @RequestParam(required = false) Integer sidoGunguCode,
+        @RequestParam(required = false) Integer sidoCode,
         @RequestParam(defaultValue = "false") boolean teenPossibleOnly,
         @RequestParam(defaultValue = "false") boolean beforeDeadlineOnly,
         Pageable pageable) {
 
-        ActivityFilterRequest request = new ActivityFilterRequest(category, teenPossibleOnly,
-            beforeDeadlineOnly);
+        ActivityFilterRequest request = ActivityFilterRequest.builder()
+            .category(category)
+            .sidoGunguCode(sidoGunguCode)
+            .sidoCode(sidoCode)
+            .teenPossibleOnly(teenPossibleOnly)
+            .beforeDeadlineOnly(beforeDeadlineOnly)
+            .build();
+
         return activityService.findSlice(request, pageable);
     }
 

--- a/src/main/java/com/gamsa/activity/controller/DistrictController.java
+++ b/src/main/java/com/gamsa/activity/controller/DistrictController.java
@@ -1,0 +1,38 @@
+package com.gamsa.activity.controller;
+
+import com.gamsa.activity.dto.DistrictFindAllResponse;
+import com.gamsa.activity.dto.DistrictSaveRequest;
+import com.gamsa.activity.service.DistrictService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/districts")
+public class DistrictController {
+
+    private final DistrictService districtService;
+
+    @PostMapping
+    public ResponseEntity<String> save(@RequestBody DistrictSaveRequest saveRequest) {
+        districtService.save(saveRequest);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @GetMapping("/sido")
+    public List<DistrictFindAllResponse> findAllSido() {
+        return districtService.findAllSido();
+    }
+
+    @GetMapping("/gungu")
+    public List<DistrictFindAllResponse> findAllGungu() {
+        return districtService.findAllGungu();
+    }
+}

--- a/src/main/java/com/gamsa/activity/domain/Activity.java
+++ b/src/main/java/com/gamsa/activity/domain/Activity.java
@@ -29,4 +29,5 @@ public class Activity {
     private String url;
     private Category category;
     private Institute institute;
+    private District sidoGungu;
 }

--- a/src/main/java/com/gamsa/activity/domain/District.java
+++ b/src/main/java/com/gamsa/activity/domain/District.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public class District {
 
     private int sidoCode;
-    private int gunguCode;
+    private int sidoGunguCode;
     private String sidoName;
     private String gunguName;
     private boolean sido;

--- a/src/main/java/com/gamsa/activity/domain/District.java
+++ b/src/main/java/com/gamsa/activity/domain/District.java
@@ -1,0 +1,15 @@
+package com.gamsa.activity.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class District {
+
+    private int sidoCode;
+    private int gunguCode;
+    private String sidoName;
+    private String gunguName;
+    private boolean sido;
+}

--- a/src/main/java/com/gamsa/activity/domain/District.java
+++ b/src/main/java/com/gamsa/activity/domain/District.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 @Builder
 public class District {
 
-    private int sidoCode;
     private int sidoGunguCode;
+    private int sidoCode;
     private String sidoName;
     private String gunguName;
     private boolean sido;

--- a/src/main/java/com/gamsa/activity/domain/Institute.java
+++ b/src/main/java/com/gamsa/activity/domain/Institute.java
@@ -13,6 +13,6 @@ public class Institute {
     private String location;
     private BigDecimal latitude;
     private BigDecimal longitude;
-    // Todo 시군구 코드
+    private District sidoGungu;
     private String phone;
 }

--- a/src/main/java/com/gamsa/activity/dto/ActivityDetailResponse.java
+++ b/src/main/java/com/gamsa/activity/dto/ActivityDetailResponse.java
@@ -33,6 +33,7 @@ public class ActivityDetailResponse {
     private final String url;
     private final Category category;
     private final InstituteDetailResponse institute;
+    private final DistrictDetailResponse sidoGungu;
 
     public static ActivityDetailResponse from(Activity activity) {
         return ActivityDetailResponse.builder()
@@ -56,6 +57,7 @@ public class ActivityDetailResponse {
             .url(activity.getUrl())
             .category(activity.getCategory())
             .institute(InstituteDetailResponse.from(activity.getInstitute()))
+            .sidoGungu(DistrictDetailResponse.from(activity.getSidoGungu()))
             .build();
     }
 }

--- a/src/main/java/com/gamsa/activity/dto/ActivityFilterRequest.java
+++ b/src/main/java/com/gamsa/activity/dto/ActivityFilterRequest.java
@@ -1,17 +1,23 @@
 package com.gamsa.activity.dto;
 
 import com.gamsa.activity.constant.Category;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
+@Builder
 @RequiredArgsConstructor
 public class ActivityFilterRequest {
 
     // 카테고리
     private final Category category;
 
-    // Todo 지역
+    // 시도군구 코드
+    private final Integer sidoGunguCode;
+
+    // 시도 코드
+    private final Integer sidoCode;
 
     // 청소년 가능한 것만
     private final boolean teenPossibleOnly;

--- a/src/main/java/com/gamsa/activity/dto/ActivitySaveRequest.java
+++ b/src/main/java/com/gamsa/activity/dto/ActivitySaveRequest.java
@@ -2,6 +2,7 @@ package com.gamsa.activity.dto;
 
 import com.gamsa.activity.constant.Category;
 import com.gamsa.activity.domain.Activity;
+import com.gamsa.activity.domain.District;
 import com.gamsa.activity.domain.Institute;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -33,8 +34,9 @@ public class ActivitySaveRequest {
     private final String url;
     private final Category category;
     private final Long instituteId;
+    private final Integer sidoGunguCode;
 
-    public Activity toModel(Institute institute) {
+    public Activity toModel(Institute institute, District sidoGungu) {
         return Activity.builder()
             .actId(actId)
             .actTitle(actTitle)
@@ -56,6 +58,7 @@ public class ActivitySaveRequest {
             .url(url)
             .category(category)
             .institute(institute)
+            .sidoGungu(sidoGungu)
             .build();
     }
 }

--- a/src/main/java/com/gamsa/activity/dto/DistrictDetailResponse.java
+++ b/src/main/java/com/gamsa/activity/dto/DistrictDetailResponse.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @Builder
 @RequiredArgsConstructor
-public class DistrictSaveRequest {
+public class DistrictDetailResponse {
 
     private final int sidoGunguCode;
     private final int sidoCode;
@@ -16,13 +16,13 @@ public class DistrictSaveRequest {
     private final String gunguName;
     private final boolean sido;
 
-    public District toModel() {
-        return District.builder()
-            .sidoGunguCode(sidoGunguCode)
-            .sidoCode(sidoCode)
-            .sidoName(sidoName)
-            .gunguName(gunguName)
-            .sido(sido)
+    public static DistrictDetailResponse from(District district) {
+        return DistrictDetailResponse.builder()
+            .sidoGunguCode(district.getSidoGunguCode())
+            .sidoCode(district.getSidoCode())
+            .sidoName(district.getSidoName())
+            .gunguName(district.getGunguName())
+            .sido(district.isSido())
             .build();
     }
 }

--- a/src/main/java/com/gamsa/activity/dto/DistrictFindAllResponse.java
+++ b/src/main/java/com/gamsa/activity/dto/DistrictFindAllResponse.java
@@ -10,16 +10,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class DistrictFindAllResponse {
 
-    private final int sidoCode;
     private final int sidoGunguCode;
+    private final int sidoCode;
     private final String sidoName;
     private final String gunguName;
     private final boolean sido;
 
     public static DistrictFindAllResponse from(District district) {
         return DistrictFindAllResponse.builder()
-            .sidoCode(district.getSidoCode())
             .sidoGunguCode(district.getSidoGunguCode())
+            .sidoCode(district.getSidoCode())
             .sidoName(district.getSidoName())
             .gunguName(district.getGunguName())
             .sido(district.isSido())

--- a/src/main/java/com/gamsa/activity/dto/DistrictFindAllResponse.java
+++ b/src/main/java/com/gamsa/activity/dto/DistrictFindAllResponse.java
@@ -1,0 +1,28 @@
+package com.gamsa.activity.dto;
+
+import com.gamsa.activity.domain.District;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class DistrictFindAllResponse {
+
+    private final int sidoCode;
+    private final int gunguCode;
+    private final String sidoName;
+    private final String gunguName;
+    private final boolean sido;
+
+    public static DistrictFindAllResponse from(District district) {
+        return DistrictFindAllResponse.builder()
+            .sidoCode(district.getSidoCode())
+            .gunguCode(district.getGunguCode())
+            .sidoName(district.getSidoName())
+            .gunguName(district.getGunguName())
+            .sido(district.isSido())
+            .build();
+    }
+}

--- a/src/main/java/com/gamsa/activity/dto/DistrictFindAllResponse.java
+++ b/src/main/java/com/gamsa/activity/dto/DistrictFindAllResponse.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 public class DistrictFindAllResponse {
 
     private final int sidoCode;
-    private final int gunguCode;
+    private final int sidoGunguCode;
     private final String sidoName;
     private final String gunguName;
     private final boolean sido;
@@ -19,7 +19,7 @@ public class DistrictFindAllResponse {
     public static DistrictFindAllResponse from(District district) {
         return DistrictFindAllResponse.builder()
             .sidoCode(district.getSidoCode())
-            .gunguCode(district.getGunguCode())
+            .sidoGunguCode(district.getSidoGunguCode())
             .sidoName(district.getSidoName())
             .gunguName(district.getGunguName())
             .sido(district.isSido())

--- a/src/main/java/com/gamsa/activity/dto/DistrictSaveRequest.java
+++ b/src/main/java/com/gamsa/activity/dto/DistrictSaveRequest.java
@@ -1,0 +1,28 @@
+package com.gamsa.activity.dto;
+
+import com.gamsa.activity.domain.District;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class DistrictSaveRequest {
+
+    private final int sidoCode;
+    private final int gunguCode;
+    private final String sidoName;
+    private final String gunguName;
+    private final boolean sido;
+
+    public District toModel() {
+        return District.builder()
+            .sidoCode(sidoCode)
+            .gunguCode(gunguCode)
+            .sidoName(sidoName)
+            .gunguName(gunguName)
+            .sido(sido)
+            .build();
+    }
+}

--- a/src/main/java/com/gamsa/activity/dto/DistrictSaveRequest.java
+++ b/src/main/java/com/gamsa/activity/dto/DistrictSaveRequest.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 public class DistrictSaveRequest {
 
     private final int sidoCode;
-    private final int gunguCode;
+    private final int sidoGunguCode;
     private final String sidoName;
     private final String gunguName;
     private final boolean sido;
@@ -19,7 +19,7 @@ public class DistrictSaveRequest {
     public District toModel() {
         return District.builder()
             .sidoCode(sidoCode)
-            .gunguCode(gunguCode)
+            .sidoGunguCode(sidoGunguCode)
             .sidoName(sidoName)
             .gunguName(gunguName)
             .sido(sido)

--- a/src/main/java/com/gamsa/activity/dto/InstituteDetailResponse.java
+++ b/src/main/java/com/gamsa/activity/dto/InstituteDetailResponse.java
@@ -16,7 +16,6 @@ public class InstituteDetailResponse {
     private final String location;
     private final BigDecimal latitude;
     private final BigDecimal longitude;
-    // Todo 시군구 코드
     private final String phone;
 
     public static InstituteDetailResponse from(Institute institute) {

--- a/src/main/java/com/gamsa/activity/dto/InstituteSaveRequest.java
+++ b/src/main/java/com/gamsa/activity/dto/InstituteSaveRequest.java
@@ -1,5 +1,6 @@
 package com.gamsa.activity.dto;
 
+import com.gamsa.activity.domain.District;
 import com.gamsa.activity.domain.Institute;
 import java.math.BigDecimal;
 import lombok.Builder;
@@ -13,15 +14,17 @@ public class InstituteSaveRequest {
     private String location;
     private BigDecimal latitude;
     private BigDecimal longitude;
-    // Todo 시군구 코드
+    private int sidoCode;
+    private int sidoGunguCode;
     private String phone;
 
-    public Institute toModel() {
+    public Institute toModel(District district) {
         return Institute.builder()
             .name(name)
             .location(location)
             .latitude(latitude)
             .longitude(longitude)
+            .sidoGungu(district)
             .phone(phone)
             .build();
     }

--- a/src/main/java/com/gamsa/activity/entity/ActivityJpaEntity.java
+++ b/src/main/java/com/gamsa/activity/entity/ActivityJpaEntity.java
@@ -99,6 +99,10 @@ public class ActivityJpaEntity extends BaseEntity {
     @JoinColumn(name = "institute_id")
     private InstituteJpaEntity institute;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sido_gungu_code", referencedColumnName = "sido_gungu_code")
+    private DistrictJpaEntity sidoGungu;
+
     public static ActivityJpaEntity from(Activity activity) {
         return ActivityJpaEntity.builder()
             .actId(activity.getActId())
@@ -121,6 +125,7 @@ public class ActivityJpaEntity extends BaseEntity {
             .url(activity.getUrl())
             .category(activity.getCategory())
             .institute(InstituteJpaEntity.from(activity.getInstitute()))
+            .sidoGungu(DistrictJpaEntity.from(activity.getSidoGungu()))
             .build();
     }
 
@@ -146,6 +151,7 @@ public class ActivityJpaEntity extends BaseEntity {
             .url(url)
             .category(category)
             .institute(institute.toModel())
+            .sidoGungu(sidoGungu.toModel())
             .build();
     }
 

--- a/src/main/java/com/gamsa/activity/entity/DistrictJpaEntity.java
+++ b/src/main/java/com/gamsa/activity/entity/DistrictJpaEntity.java
@@ -1,0 +1,64 @@
+package com.gamsa.activity.entity;
+
+import com.gamsa.activity.domain.District;
+import com.gamsa.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "District")
+public class DistrictJpaEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "district_id")
+    private Integer districtId;
+
+    @Column(name = "sido_code")
+    private int sidoCode;
+
+    @Column(name = "gungu_code")
+    private int gunguCode;
+
+    @Column(name = "sido_name", length = 15)
+    private String sidoName;
+
+    @Column(name = "gungu_name", length = 15)
+    private String gunguName;
+
+    @Column(name = "sido")
+    private boolean sido;
+
+    public static DistrictJpaEntity from(District district) {
+        return DistrictJpaEntity.builder()
+            .sidoCode(district.getSidoCode())
+            .gunguCode(district.getGunguCode())
+            .sidoName(district.getSidoName())
+            .gunguName(district.getGunguName())
+            .sido(district.isSido())
+            .build();
+    }
+
+    public District toModel() {
+        return District.builder()
+            .sidoCode(getSidoCode())
+            .gunguCode(getGunguCode())
+            .sidoName(getSidoName())
+            .gunguName(getGunguName())
+            .sido(isSido())
+            .build();
+    }
+}

--- a/src/main/java/com/gamsa/activity/entity/DistrictJpaEntity.java
+++ b/src/main/java/com/gamsa/activity/entity/DistrictJpaEntity.java
@@ -27,25 +27,25 @@ public class DistrictJpaEntity extends BaseEntity {
     @Column(name = "district_id")
     private Integer districtId;
 
-    @Column(name = "sido_code")
+    @Column(name = "sido_code", nullable = false)
     private int sidoCode;
 
-    @Column(name = "gungu_code")
-    private int gunguCode;
+    @Column(name = "sido_gungu_code", nullable = false, unique = true)
+    private int sidoGunguCode;
 
-    @Column(name = "sido_name", length = 15)
+    @Column(name = "sido_name", length = 15, nullable = false)
     private String sidoName;
 
     @Column(name = "gungu_name", length = 15)
     private String gunguName;
 
-    @Column(name = "sido")
+    @Column(name = "sido", nullable = false)
     private boolean sido;
 
     public static DistrictJpaEntity from(District district) {
         return DistrictJpaEntity.builder()
             .sidoCode(district.getSidoCode())
-            .gunguCode(district.getGunguCode())
+            .sidoGunguCode(district.getSidoGunguCode())
             .sidoName(district.getSidoName())
             .gunguName(district.getGunguName())
             .sido(district.isSido())
@@ -55,7 +55,7 @@ public class DistrictJpaEntity extends BaseEntity {
     public District toModel() {
         return District.builder()
             .sidoCode(getSidoCode())
-            .gunguCode(getGunguCode())
+            .sidoGunguCode(getSidoGunguCode())
             .sidoName(getSidoName())
             .gunguName(getGunguName())
             .sido(isSido())

--- a/src/main/java/com/gamsa/activity/entity/DistrictJpaEntity.java
+++ b/src/main/java/com/gamsa/activity/entity/DistrictJpaEntity.java
@@ -4,8 +4,6 @@ import com.gamsa.activity.domain.District;
 import com.gamsa.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -23,15 +21,11 @@ import lombok.NoArgsConstructor;
 public class DistrictJpaEntity extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "district_id")
-    private Integer districtId;
+    @Column(name = "sido_gungu_code", nullable = false, unique = true)
+    private int sidoGunguCode;
 
     @Column(name = "sido_code", nullable = false)
     private int sidoCode;
-
-    @Column(name = "sido_gungu_code", nullable = false, unique = true)
-    private int sidoGunguCode;
 
     @Column(name = "sido_name", length = 15, nullable = false)
     private String sidoName;
@@ -44,8 +38,8 @@ public class DistrictJpaEntity extends BaseEntity {
 
     public static DistrictJpaEntity from(District district) {
         return DistrictJpaEntity.builder()
-            .sidoCode(district.getSidoCode())
             .sidoGunguCode(district.getSidoGunguCode())
+            .sidoCode(district.getSidoCode())
             .sidoName(district.getSidoName())
             .gunguName(district.getGunguName())
             .sido(district.isSido())
@@ -54,8 +48,8 @@ public class DistrictJpaEntity extends BaseEntity {
 
     public District toModel() {
         return District.builder()
-            .sidoCode(getSidoCode())
             .sidoGunguCode(getSidoGunguCode())
+            .sidoCode(getSidoCode())
             .sidoName(getSidoName())
             .gunguName(getGunguName())
             .sido(isSido())

--- a/src/main/java/com/gamsa/activity/entity/InstituteJpaEntity.java
+++ b/src/main/java/com/gamsa/activity/entity/InstituteJpaEntity.java
@@ -4,9 +4,12 @@ import com.gamsa.activity.domain.Institute;
 import com.gamsa.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import lombok.AccessLevel;
@@ -40,7 +43,9 @@ public class InstituteJpaEntity extends BaseEntity {
     @Column(name = "longitude")
     private BigDecimal longitude;
 
-    // Todo 시군구 코드
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sido_gungu_code", referencedColumnName = "sido_gungu_code")
+    private DistrictJpaEntity sidoGungu;
 
     @Column(name = "phone", length = 12)
     private String phone;
@@ -52,6 +57,7 @@ public class InstituteJpaEntity extends BaseEntity {
             .location(institute.getLocation())
             .latitude(institute.getLatitude())
             .longitude(institute.getLongitude())
+            .sidoGungu(DistrictJpaEntity.from(institute.getSidoGungu()))
             .phone(institute.getPhone())
             .build();
     }
@@ -63,6 +69,7 @@ public class InstituteJpaEntity extends BaseEntity {
             .location(location)
             .latitude(latitude)
             .longitude(longitude)
+            .sidoGungu(sidoGungu.toModel())
             .phone(phone)
             .build();
     }

--- a/src/main/java/com/gamsa/activity/repository/ActivityFilterBuilder.java
+++ b/src/main/java/com/gamsa/activity/repository/ActivityFilterBuilder.java
@@ -13,6 +13,8 @@ public class ActivityFilterBuilder {
         BooleanBuilder filterBuilder = new BooleanBuilder();
 
         eqCategory(filterBuilder, request.getCategory());
+        eqSidoGunguCode(filterBuilder, request.getSidoGunguCode());
+        eqSidoCode(filterBuilder, request.getSidoCode());
         isTeenPossibleOnly(filterBuilder, request.isTeenPossibleOnly());
         isDeadlineEndOnly(filterBuilder, request.isBeforeDeadlineOnly());
 
@@ -22,6 +24,18 @@ public class ActivityFilterBuilder {
     public static void eqCategory(BooleanBuilder filterBuilder, Category category) {
         if (category != null) {
             filterBuilder.and(activityJpaEntity.category.eq(category));
+        }
+    }
+
+    public static void eqSidoGunguCode(BooleanBuilder filterBuilder, Integer sidoGunguCode) {
+        if (sidoGunguCode != null) {
+            filterBuilder.and(activityJpaEntity.sidoGungu.sidoGunguCode.eq(sidoGunguCode));
+        }
+    }
+
+    public static void eqSidoCode(BooleanBuilder filterBuilder, Integer sidoCode) {
+        if (sidoCode != null) {
+            filterBuilder.and(activityJpaEntity.sidoGungu.sidoCode.eq(sidoCode));
         }
     }
 

--- a/src/main/java/com/gamsa/activity/repository/DistrictJpaRepository.java
+++ b/src/main/java/com/gamsa/activity/repository/DistrictJpaRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DistrictJpaRepository extends JpaRepository<DistrictJpaEntity, Integer> {
 
-    Optional<DistrictJpaEntity> findByGunguCode(int gunguCode);
+    Optional<DistrictJpaEntity> findBySidoGunguCode(int gunguCode);
 
     List<DistrictJpaEntity> findAllBySido(boolean sido);
 }

--- a/src/main/java/com/gamsa/activity/repository/DistrictJpaRepository.java
+++ b/src/main/java/com/gamsa/activity/repository/DistrictJpaRepository.java
@@ -1,0 +1,13 @@
+package com.gamsa.activity.repository;
+
+import com.gamsa.activity.entity.DistrictJpaEntity;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DistrictJpaRepository extends JpaRepository<DistrictJpaEntity, Integer> {
+
+    Optional<DistrictJpaEntity> findByGunguCode(int gunguCode);
+
+    List<DistrictJpaEntity> findAllBySido(boolean sido);
+}

--- a/src/main/java/com/gamsa/activity/repository/DistrictRepository.java
+++ b/src/main/java/com/gamsa/activity/repository/DistrictRepository.java
@@ -8,7 +8,7 @@ public interface DistrictRepository {
 
     void save(District district);
 
-    Optional<District> findByGunguCode(int gunguCode);
+    Optional<District> findBySidoGunguCode(int gunguCode);
 
     List<District> findAllBysido(boolean sido);
 }

--- a/src/main/java/com/gamsa/activity/repository/DistrictRepository.java
+++ b/src/main/java/com/gamsa/activity/repository/DistrictRepository.java
@@ -1,0 +1,14 @@
+package com.gamsa.activity.repository;
+
+import com.gamsa.activity.domain.District;
+import java.util.List;
+import java.util.Optional;
+
+public interface DistrictRepository {
+
+    void save(District district);
+
+    Optional<District> findByGunguCode(int gunguCode);
+
+    List<District> findAllBysido(boolean sido);
+}

--- a/src/main/java/com/gamsa/activity/repository/DistrictRepositoryImpl.java
+++ b/src/main/java/com/gamsa/activity/repository/DistrictRepositoryImpl.java
@@ -19,8 +19,8 @@ public class DistrictRepositoryImpl implements DistrictRepository {
     }
 
     @Override
-    public Optional<District> findByGunguCode(int gunguCode) {
-        return districtJpaRepository.findByGunguCode(gunguCode)
+    public Optional<District> findBySidoGunguCode(int gunguCode) {
+        return districtJpaRepository.findBySidoGunguCode(gunguCode)
             .map(DistrictJpaEntity::toModel);
     }
 

--- a/src/main/java/com/gamsa/activity/repository/DistrictRepositoryImpl.java
+++ b/src/main/java/com/gamsa/activity/repository/DistrictRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.gamsa.activity.repository;
+
+import com.gamsa.activity.domain.District;
+import com.gamsa.activity.entity.DistrictJpaEntity;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class DistrictRepositoryImpl implements DistrictRepository {
+
+    private final DistrictJpaRepository districtJpaRepository;
+
+    @Override
+    public void save(District district) {
+        districtJpaRepository.save(DistrictJpaEntity.from(district));
+    }
+
+    @Override
+    public Optional<District> findByGunguCode(int gunguCode) {
+        return districtJpaRepository.findByGunguCode(gunguCode)
+            .map(DistrictJpaEntity::toModel);
+    }
+
+    @Override
+    public List<District> findAllBysido(boolean sido) {
+        return districtJpaRepository.findAllBySido(sido).stream()
+            .map(DistrictJpaEntity::toModel)
+            .toList();
+    }
+}

--- a/src/main/java/com/gamsa/activity/service/ActivityService.java
+++ b/src/main/java/com/gamsa/activity/service/ActivityService.java
@@ -2,6 +2,7 @@ package com.gamsa.activity.service;
 
 import com.gamsa.activity.constant.ActivityErrorCode;
 import com.gamsa.activity.domain.Activity;
+import com.gamsa.activity.domain.District;
 import com.gamsa.activity.domain.Institute;
 import com.gamsa.activity.dto.ActivityDetailResponse;
 import com.gamsa.activity.dto.ActivityFilterRequest;
@@ -9,6 +10,7 @@ import com.gamsa.activity.dto.ActivityFindSliceResponse;
 import com.gamsa.activity.dto.ActivitySaveRequest;
 import com.gamsa.activity.exception.ActivityException;
 import com.gamsa.activity.repository.ActivityRepository;
+import com.gamsa.activity.repository.DistrictRepository;
 import com.gamsa.activity.repository.InstituteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +23,7 @@ public class ActivityService {
 
     private final ActivityRepository activityRepository;
     private final InstituteRepository instituteRepository;
+    private final DistrictRepository districtRepository;
 
     public void save(ActivitySaveRequest saveRequest) {
         // 중복 여부 확인
@@ -32,7 +35,11 @@ public class ActivityService {
         Institute institute = instituteRepository.findById(saveRequest.getInstituteId())
             .orElseThrow(() -> new ActivityException(ActivityErrorCode.INSTITUTE_NOT_EXISTS));
 
-        activityRepository.save(saveRequest.toModel(institute));
+        // 시도, 군구 존재 확인
+        District sidoGungu = districtRepository.findBySidoGunguCode(saveRequest.getSidoGunguCode())
+            .orElseThrow(() -> new ActivityException(ActivityErrorCode.DISTRICT_NOT_EXISTS));
+
+        activityRepository.save(saveRequest.toModel(institute, sidoGungu));
     }
 
     public Slice<ActivityFindSliceResponse> findSlice(ActivityFilterRequest request,

--- a/src/main/java/com/gamsa/activity/service/DistrictService.java
+++ b/src/main/java/com/gamsa/activity/service/DistrictService.java
@@ -16,7 +16,7 @@ public class DistrictService {
     private final DistrictRepository districtRepository;
 
     public void save(DistrictSaveRequest saveRequest) {
-        districtRepository.findByGunguCode(saveRequest.getSidoGunguCode())
+        districtRepository.findBySidoGunguCode(saveRequest.getSidoGunguCode())
             .ifPresent(district -> {
                 throw new ActivityException(ActivityErrorCode.DISTRICT_ALREADY_EXISTS);
             });

--- a/src/main/java/com/gamsa/activity/service/DistrictService.java
+++ b/src/main/java/com/gamsa/activity/service/DistrictService.java
@@ -1,0 +1,47 @@
+package com.gamsa.activity.service;
+
+import com.gamsa.activity.constant.ActivityErrorCode;
+import com.gamsa.activity.dto.DistrictFindAllResponse;
+import com.gamsa.activity.dto.DistrictSaveRequest;
+import com.gamsa.activity.exception.ActivityException;
+import com.gamsa.activity.repository.DistrictRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class DistrictService {
+
+    private final DistrictRepository districtRepository;
+
+    public void save(DistrictSaveRequest saveRequest) {
+        districtRepository.findByGunguCode(saveRequest.getGunguCode())
+            .ifPresent(district -> {
+                throw new ActivityException(ActivityErrorCode.DISTRICT_ALREADY_EXISTS);
+            });
+        districtRepository.save(saveRequest.toModel());
+    }
+
+    /**
+     * 시도 코드 데이터만 반환
+     *
+     * @return 시도 코드 리스트
+     */
+    public List<DistrictFindAllResponse> findAllSido() {
+        return districtRepository.findAllBysido(true).stream()
+            .map(DistrictFindAllResponse::from)
+            .toList();
+    }
+
+    /**
+     * 군구 코드 데이터만 반환
+     *
+     * @return 군구 코드 리스트
+     */
+    public List<DistrictFindAllResponse> findAllGungu() {
+        return districtRepository.findAllBysido(false).stream()
+            .map(DistrictFindAllResponse::from)
+            .toList();
+    }
+}

--- a/src/main/java/com/gamsa/activity/service/DistrictService.java
+++ b/src/main/java/com/gamsa/activity/service/DistrictService.java
@@ -16,7 +16,7 @@ public class DistrictService {
     private final DistrictRepository districtRepository;
 
     public void save(DistrictSaveRequest saveRequest) {
-        districtRepository.findByGunguCode(saveRequest.getGunguCode())
+        districtRepository.findByGunguCode(saveRequest.getSidoGunguCode())
             .ifPresent(district -> {
                 throw new ActivityException(ActivityErrorCode.DISTRICT_ALREADY_EXISTS);
             });

--- a/src/main/java/com/gamsa/activity/service/InstituteService.java
+++ b/src/main/java/com/gamsa/activity/service/InstituteService.java
@@ -1,8 +1,10 @@
 package com.gamsa.activity.service;
 
 import com.gamsa.activity.constant.ActivityErrorCode;
+import com.gamsa.activity.domain.District;
 import com.gamsa.activity.dto.InstituteSaveRequest;
 import com.gamsa.activity.exception.ActivityException;
+import com.gamsa.activity.repository.DistrictRepository;
 import com.gamsa.activity.repository.InstituteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,12 +14,17 @@ import org.springframework.stereotype.Service;
 public class InstituteService {
 
     private final InstituteRepository instituteRepository;
+    private final DistrictRepository districtRepository;
 
     public void save(InstituteSaveRequest saveRequest) {
         instituteRepository.findByName(saveRequest.getName())
             .ifPresent(institute -> {
                 throw new ActivityException(ActivityErrorCode.INSTITUTE_ALREADY_EXISTS);
             });
-        instituteRepository.save(saveRequest.toModel());
+
+        District district = districtRepository.findBySidoGunguCode(saveRequest.getSidoGunguCode())
+            .orElseThrow(() -> new ActivityException(ActivityErrorCode.DISTRICT_NOT_EXISTS));
+
+        instituteRepository.save(saveRequest.toModel(district));
     }
 }

--- a/src/test/java/com/gamsa/activity/entity/ActivityJpaEntityTest.java
+++ b/src/test/java/com/gamsa/activity/entity/ActivityJpaEntityTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.gamsa.activity.constant.Category;
 import com.gamsa.activity.domain.Activity;
+import com.gamsa.activity.domain.District;
 import com.gamsa.activity.domain.Institute;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -14,12 +15,21 @@ class ActivityJpaEntityTest {
     @Test
     void 도메인모델에서_JPA엔티티로_변환() {
         // given
+        District district = District.builder()
+            .sidoCode(1234)
+            .sidoGunguCode(8888)
+            .sidoName("서울특별시")
+            .gunguName("강남구")
+            .sido(false)
+            .build();
+
         Institute institute = Institute.builder()
             .instituteId(1L)
             .name("도서관")
             .location("서울시")
             .latitude(new BigDecimal("123456789.12341234"))
             .longitude(new BigDecimal("987654321.43214321"))
+            .sidoGungu(district)
             .phone("010xxxxxxxx")
             .build();
 
@@ -44,6 +54,7 @@ class ActivityJpaEntityTest {
             .url("https://...")
             .category(Category.OTHER_ACTIVITIES)
             .institute(institute)
+            .sidoGungu(district)
             .build();
 
         // when
@@ -56,12 +67,21 @@ class ActivityJpaEntityTest {
     @Test
     void JPA엔티에서_도메인모델로_변환() {
         // given
+        DistrictJpaEntity districtJpaEntity = DistrictJpaEntity.builder()
+            .sidoCode(1234)
+            .sidoGunguCode(8888)
+            .sidoName("서울특별시")
+            .gunguName("강남구")
+            .sido(false)
+            .build();
+
         InstituteJpaEntity institute = InstituteJpaEntity.builder()
             .instituteId(1L)
             .name("도서관")
             .location("서울시")
             .latitude(new BigDecimal("123456789.12341234"))
             .longitude(new BigDecimal("987654321.43214321"))
+            .sidoGungu(districtJpaEntity)
             .phone("010xxxxxxxx")
             .build();
 
@@ -86,6 +106,7 @@ class ActivityJpaEntityTest {
             .url("https://...")
             .category(Category.OTHER_ACTIVITIES)
             .institute(institute)
+            .sidoGungu(districtJpaEntity)
             .build();
 
         // when

--- a/src/test/java/com/gamsa/activity/entity/InstituteJpaEntityTest.java
+++ b/src/test/java/com/gamsa/activity/entity/InstituteJpaEntityTest.java
@@ -2,6 +2,7 @@ package com.gamsa.activity.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.gamsa.activity.domain.District;
 import com.gamsa.activity.domain.Institute;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.DisplayName;
@@ -9,16 +10,26 @@ import org.junit.jupiter.api.Test;
 
 class InstituteJpaEntityTest {
 
+
     @Test
     @DisplayName("도메인 모델에서 JPA엔티티로 변환")
     void changeToJpaEntity() {
         // given
+        District district = District.builder()
+            .sidoCode(1234)
+            .sidoGunguCode(8888)
+            .sidoName("서울특별시")
+            .gunguName("강남구")
+            .sido(false)
+            .build();
+
         Institute model = Institute.builder()
             .instituteId(1L)
             .name("도서관")
             .location("서울시")
             .latitude(new BigDecimal("123456789.12341234"))
             .longitude(new BigDecimal("987654321.43214321"))
+            .sidoGungu(district)
             .phone("010xxxxxxxx")
             .build();
         // when
@@ -31,12 +42,21 @@ class InstituteJpaEntityTest {
     @DisplayName("JPA엔티티에서 도메인 모델로 변환")
     void changeToDomainModel() {
         // given
+        DistrictJpaEntity districtJpaEntity = DistrictJpaEntity.builder()
+            .sidoCode(1234)
+            .sidoGunguCode(8888)
+            .sidoName("서울특별시")
+            .gunguName("강남구")
+            .sido(false)
+            .build();
+
         InstituteJpaEntity jpaEntity = InstituteJpaEntity.builder()
             .instituteId(1L)
             .name("도서관")
             .location("서울시")
             .latitude(new BigDecimal("123456789.12341234"))
             .longitude(new BigDecimal("987654321.43214321"))
+            .sidoGungu(districtJpaEntity)
             .phone("010xxxxxxxx")
             .build();
         // when

--- a/src/test/java/com/gamsa/activity/repository/ActivityJpaRepositoryTest.java
+++ b/src/test/java/com/gamsa/activity/repository/ActivityJpaRepositoryTest.java
@@ -92,16 +92,16 @@ class ActivityJpaRepositoryTest {
 
     // 필터링
     private final ActivityFilterRequest noFilterReq = new ActivityFilterRequest(
-        null, false, false);
+        null, null, null, false, false);
 
     private final ActivityFilterRequest otherCategoryFilterReq = new ActivityFilterRequest(
-        Category.OTHER_ACTIVITIES, false, false);
+        Category.OTHER_ACTIVITIES, null, null, false, false);
 
     private final ActivityFilterRequest teenPossibleFilterReq = new ActivityFilterRequest(
-        null, true, false);
+        null, null, null, true, false);
 
     private final ActivityFilterRequest beforeDeadlineFilterReq = new ActivityFilterRequest(
-        null, false, true);
+        null, null, null, false, true);
 
     @Test
     void 새_활동_저장() {

--- a/src/test/java/com/gamsa/activity/service/ActivityServiceTest.java
+++ b/src/test/java/com/gamsa/activity/service/ActivityServiceTest.java
@@ -10,6 +10,7 @@ import com.gamsa.activity.dto.ActivitySaveRequest;
 import com.gamsa.activity.exception.ActivityException;
 import com.gamsa.activity.stub.StubEmptyActivityRepository;
 import com.gamsa.activity.stub.StubExistsActivityRepository;
+import com.gamsa.activity.stub.StubExistsDistrictRepository;
 import com.gamsa.activity.stub.StubExistsInstituteRepository;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Assertions;
@@ -41,6 +42,7 @@ class ActivityServiceTest {
         .url("https://...")
         .category(Category.OTHER_ACTIVITIES)
         .instituteId(1L)
+        .sidoGunguCode(1)
         .build();
 
     @Test
@@ -48,7 +50,8 @@ class ActivityServiceTest {
         // given
         ActivityService activityService = new ActivityService(
             new StubEmptyActivityRepository(),
-            new StubExistsInstituteRepository()
+            new StubExistsInstituteRepository(),
+            new StubExistsDistrictRepository()
         );
 
         // then
@@ -64,7 +67,8 @@ class ActivityServiceTest {
         // given
         ActivityService activityService = new ActivityService(
             new StubExistsActivityRepository(),
-            new StubExistsInstituteRepository()
+            new StubExistsInstituteRepository(),
+            new StubExistsDistrictRepository()
         );
 
         // then
@@ -79,7 +83,8 @@ class ActivityServiceTest {
         // given
         ActivityService activityService = new ActivityService(
             new StubEmptyActivityRepository(),
-            new StubExistsInstituteRepository()
+            new StubExistsInstituteRepository(),
+            new StubExistsDistrictRepository()
         );
 
         // when
@@ -95,7 +100,8 @@ class ActivityServiceTest {
         // given
         ActivityService activityService = new ActivityService(
             new StubExistsActivityRepository(),
-            new StubExistsInstituteRepository()
+            new StubExistsInstituteRepository(),
+            new StubExistsDistrictRepository()
         );
 
         // when
@@ -110,7 +116,8 @@ class ActivityServiceTest {
         // given
         ActivityService activityService = new ActivityService(
             new StubEmptyActivityRepository(),
-            new StubExistsInstituteRepository()
+            new StubExistsInstituteRepository(),
+            new StubExistsDistrictRepository()
         );
 
         // then

--- a/src/test/java/com/gamsa/activity/service/InstituteServiceTest.java
+++ b/src/test/java/com/gamsa/activity/service/InstituteServiceTest.java
@@ -7,6 +7,7 @@ import com.gamsa.activity.constant.ActivityErrorCode;
 import com.gamsa.activity.dto.InstituteSaveRequest;
 import com.gamsa.activity.exception.ActivityException;
 import com.gamsa.activity.stub.StubEmptyInstituteRepository;
+import com.gamsa.activity.stub.StubExistsDistrictRepository;
 import com.gamsa.activity.stub.StubExistsInstituteRepository;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.DisplayName;
@@ -27,7 +28,10 @@ class InstituteServiceTest {
     @DisplayName("봉사기관을 생성한다.")
     void save() {
         // given
-        InstituteService service = new InstituteService(new StubEmptyInstituteRepository());
+        InstituteService service = new InstituteService(
+            new StubEmptyInstituteRepository(),
+            new StubExistsDistrictRepository()
+        );
         // then
         assertDoesNotThrow(() -> {
             // when
@@ -39,7 +43,10 @@ class InstituteServiceTest {
     @DisplayName("봉시기관 동일 이름 충돌로 실패한다.")
     void saveFail() {
         // given
-        InstituteService service = new InstituteService(new StubExistsInstituteRepository());
+        InstituteService service = new InstituteService(
+            new StubExistsInstituteRepository(),
+            new StubExistsDistrictRepository()
+        );
         // then
         assertThrows(ActivityException.class, () -> {
             // when

--- a/src/test/java/com/gamsa/activity/stub/StubExistsActivityRepository.java
+++ b/src/test/java/com/gamsa/activity/stub/StubExistsActivityRepository.java
@@ -1,6 +1,7 @@
 package com.gamsa.activity.stub;
 
 import com.gamsa.activity.domain.Activity;
+import com.gamsa.activity.domain.District;
 import com.gamsa.activity.domain.Institute;
 import com.gamsa.activity.dto.ActivityFilterRequest;
 import com.gamsa.activity.repository.ActivityRepository;
@@ -13,6 +14,14 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
 public class StubExistsActivityRepository implements ActivityRepository {
+
+    private final District district = District.builder()
+        .sidoCode(1234)
+        .sidoGunguCode(8888)
+        .sidoName("서울특별시")
+        .gunguName("강남구")
+        .sido(false)
+        .build();
 
     private final Institute institute = Institute.builder()
         .instituteId(1L)
@@ -43,6 +52,7 @@ public class StubExistsActivityRepository implements ActivityRepository {
         .actPhone("032-577-3026")
         .url("https://...")
         .institute(institute)
+        .sidoGungu(district)
         .build();
 
     @Override

--- a/src/test/java/com/gamsa/activity/stub/StubExistsDistrictRepository.java
+++ b/src/test/java/com/gamsa/activity/stub/StubExistsDistrictRepository.java
@@ -1,0 +1,32 @@
+package com.gamsa.activity.stub;
+
+import com.gamsa.activity.domain.District;
+import com.gamsa.activity.repository.DistrictRepository;
+import java.util.List;
+import java.util.Optional;
+
+public class StubExistsDistrictRepository implements DistrictRepository {
+
+    private final District district = District.builder()
+        .sidoCode(1234)
+        .sidoGunguCode(8888)
+        .sidoName("서울특별시")
+        .gunguName("강남구")
+        .sido(false)
+        .build();
+
+    @Override
+    public void save(District district) {
+        // do nothing
+    }
+
+    @Override
+    public Optional<District> findBySidoGunguCode(int gunguCode) {
+        return Optional.of(district);
+    }
+
+    @Override
+    public List<District> findAllBysido(boolean sido) {
+        return List.of(district);
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

- 시도, 시군구 테이블 및 API
- 봉사활동, 봉사기관과의 연관관계 매핑
- 봉사활동 조회 시, 시도, 시군구 필터링 기능

## 🔧 앞으로의 과제

- 테스트 코드를 작성하지 못했음. 작성할 예정.

## 📝 리뷰어에게
- 시도와 시군구를 판단하는 컬럼으로 isSido를 넣으려했으나, lombok과 is~네이밍의 충돌로 인해 `sido` 라고 명명하였습니다. 혹시 관련 내용이 궁금하시다면 `@RequestBody` boolean 값 바인딩 에러 라는 키워드로 검색해보시면 나옵니다!

## ✅ 해결 이슈

- resolved #30 
